### PR TITLE
Add regex-based detection for inserting newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,27 @@ Parity features from modern editors (e.g. VSCode, Atom) are welcome as suggestio
 Branched from [9086ce8](https://github.com/reaysawa/auto-pairs/commit/9086ce897a616d78baf69ddb07ad557c5ceb1d7c).
 
 ### Merged
-- [dont-leave-insert](https://github.com/reaysawa/auto-pairs/tree/dont-leave-insert): Prevents leaving insert when using AutoPairsShortcutJump. Introduces `g:AutoPairsShortcutJump_SkipString`.
-- [prevent-character-skip](https://github.com/reaysawa/auto-pairs/tree/prevent-character-skip): Define a list of characters who shouldn't be skipped over.  Introduces `g:AutoPairsDoNotSkip`.
+#### [dont-leave-insert](https://github.com/reaysawa/auto-pairs/tree/dont-leave-insert)
+
+Prevents leaving insert when using AutoPairsShortcutJump. Introduces `g:AutoPairsShortcutJump_SkipString`.
+
+#### [prevent-character-skip](https://github.com/reaysawa/auto-pairs/tree/prevent-character-skip)
+
+Define a list of characters who shouldn't be skipped over.  Introduces `g:AutoPairsDoNotSkip`. Will be reworked later to specify which characters to skip instead, defaulting to the initial list of characters from g:AutoPairs.
+
+#### [return-with-regex](https://github.com/reaysawa/auto-pairs/tree/return-with-regex)
+
+Extends automatic newline to regexes of characters matching said expression in the following line; has been changed so that it doesn't make Vim leave insert mode anymore. Controlled with `g:AutoPairsNewline`.
 
 ### Candidates
-#### Make it possible to insert an indented line between html tags
-https://github.com/jeromedalbert/auto-pairs/tree/better-auto-pairs
+#### ~Make it possible to insert an indented line between html tags~
+~https://github.com/jeromedalbert/auto-pairs/tree/better-auto-pairs~
 
-https://github.com/jiangmiao/auto-pairs/pull/141
+~https://github.com/jiangmiao/auto-pairs/pull/141~
 
-For inserting indent after newline insertion in tag-based contexts (HTML, XML, whatever).
+~For inserting indent after newline insertion in tag-based contexts (HTML, XML, whatever).~
+
+Incorporated as *return-with-regex****.
 
 #### Close empty pairs smartly
 https://github.com/shirohana/auto-pairs/tree/waiting-for-pl-accepted
@@ -26,6 +37,7 @@ https://github.com/jiangmiao/auto-pairs/pull/172
 
 Recognizing leading whitespace in-between pairs and adding text symmetry when closing.
 
+----------
 
 Auto Pairs
 ==========

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Parity features from modern editors (e.g. VSCode, Atom) are welcome as suggestio
 
 Branched from [9086ce8](https://github.com/reaysawa/auto-pairs/commit/9086ce897a616d78baf69ddb07ad557c5ceb1d7c).
 
-### Merged
+### Merged, in order
 #### [dont-leave-insert](https://github.com/reaysawa/auto-pairs/tree/dont-leave-insert)
 
 Prevents leaving insert when using AutoPairsShortcutJump. Introduces `g:AutoPairsShortcutJump_SkipString`.
@@ -28,7 +28,7 @@ Extends automatic newline to regexes of characters matching said expression in t
 
 ~For inserting indent after newline insertion in tag-based contexts (HTML, XML, whatever).~
 
-Incorporated as *return-with-regex****.
+Incorporated as **return-with-regex**.
 
 #### Close empty pairs smartly
 https://github.com/shirohana/auto-pairs/tree/waiting-for-pl-accepted

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Parity features from modern editors (e.g. VSCode, Atom) are welcome as suggestio
 
 Branched from [9086ce8](https://github.com/reaysawa/auto-pairs/commit/9086ce897a616d78baf69ddb07ad557c5ceb1d7c).
 
-### Merged, in order
+### Merged - following the branched source as a base, discontinued
 #### [dont-leave-insert](https://github.com/reaysawa/auto-pairs/tree/dont-leave-insert)
 
 Prevents leaving insert when using AutoPairsShortcutJump. Introduces `g:AutoPairsShortcutJump_SkipString`.

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -301,6 +301,60 @@ Executes:
     inoremap <buffer> <silent> <CR> <C-R>=AutoPairsReturn()<CR>
 
 
+                                                            *g:AutoPairsNewline*
+|g:AutoPairsNewline|                                                        dict
+
+Default: same as g:AutoPairs
+
+When g:AutoPairsMapCR is turned on, it defines which preceding characters get
+a newline inserted after them upon pressing enter.
+>
+        function() {|}
+<
+>
+        function() {
+          |
+        }
+<
+
+You can specify it on a buffer basis with b:AutoPairsNewline.
+
+>
+  For instance, on `ftplugin/html.vim`
+  let b:AutoPairsNewline=extend(g:AutoPairsNewline, { '>': '</' })
+<
+
+That will cover all existing pairs and plus the `</` following expression following
+a >. Then:
+
+>
+           |
+           |  matches ">"
+           |
+           ˇ
+    <strong>|</strong> <--- matches "</"
+<
+>
+    <strong>
+      |
+    </strong>
+<
+
+Indent is referred based on the previous line and tries to respect your
+*expandtab* option.
+
+                                               *g:AutoPairsNewlineIndentCommand*
+|g:AutoPairsNewlineIndentCommand|                                           dict
+
+Defines which command is used to indent the lines after g:AutoPairsNewline is
+triggered, starting from the last line. Note: It has to reposition the cursor
+back to the new line at the end.
+
+The default command is `==k`, which indents the line pushed below and moves
+the cursor back to the new line inserted.
+
+Default: {}
+
                                                         *g:AutoPairsCenterLine*
 |g:AutoPairsCenterLine|                                                     int
 
@@ -370,3 +424,6 @@ There are 3 ways:
 Because AutoPairs uses Meta(Alt) key as a shortcut, it conflicts with some
 Swedish character such as å. To fix the issue, you need remap or disable the
 related shortcut.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -347,8 +347,7 @@ Indent is referred based on the previous line and tries to respect your
 |g:AutoPairsNewlineIndentCommand|                                           dict
 
 Defines which command is used to indent the lines after g:AutoPairsNewline is
-triggered, starting from the last line. Note: It has to reposition the cursor
-back to the new line at the end.
+triggered, starting from the last line.
 
 The default command is `==k`, which indents the line pushed below and moves
 the cursor back to the new line inserted.

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -428,7 +428,7 @@ function! AutoPairsReturn()
     call append(line_n - 1, '')
     execute 'norm! ' . get(b:AutoPairsNewlineIndentCommand, prev_char, '==k')
     if &expandtab
-      let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth + 1)
+      let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth)
     else
       let cmd = repeat("\<Tab>", max([0, matchend(prev_line, '^\t*')]) + 1)
     endif

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -18,7 +18,6 @@ end
 
 if !exists('g:AutoPairsNewline')
   let g:AutoPairsNewline = deepcopy(g:AutoPairs)
-  let g:AutoPairsNewline['>'] = '<'
 end
 
 if !exists('g:AutoPairsParens')
@@ -395,7 +394,6 @@ function! AutoPairsReturn()
   let cmd = ''
   let cur_char = line[col('.')-1]
   let next_char = line[col('.')]
-  if cur_char == '<' && next_char != '/' | return '' | endif
 
   if has_key(b:AutoPairsNewline, prev_char) && b:AutoPairsNewline[prev_char] == cur_char
     if g:AutoPairsCenterLine && winline() * 3 >= winheight(0) * 2

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -20,6 +20,10 @@ if !exists('g:AutoPairsNewline')
   let g:AutoPairsNewline = deepcopy(g:AutoPairs)
 end
 
+if !exists('g:AutoPairsNewlineIndentCommand')
+  let g:AutoPairsNewlineIndentCommand = {}
+end
+
 if !exists('g:AutoPairsParens')
   let g:AutoPairsParens = {'(':')', '[':']', '{':'}'}
 end
@@ -422,7 +426,7 @@ function! AutoPairsReturn()
 
   if has_key(b:AutoPairsNewline, prev_char) && remaining_line =~? '^\s*' . b:AutoPairsNewline[prev_char]
     call append(line_n - 1, '')
-    norm! ==k
+    execute 'norm! ' . get(b:AutoPairsNewlineIndentCommand, prev_char, '==k')
     if &expandtab
       let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth + 1)
     else
@@ -466,6 +470,10 @@ function! AutoPairsInit()
 
   if !exists('b:AutoPairsNewline')
     let b:AutoPairsNewline = g:AutoPairsNewline
+  end
+
+  if !exists('b:AutoPairsNewlineIndentCommand')
+    let b:AutoPairsNewlineIndentCommand = g:AutoPairsNewlineIndentCommand
   end
 
   if !exists('b:AutoPairsMoveCharacter')

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -425,8 +425,9 @@ function! AutoPairsReturn()
   let g:db = [prev_line, prev_char, remaining_line]
 
   if has_key(b:AutoPairsNewline, prev_char) && remaining_line =~? '^\s*' . b:AutoPairsNewline[prev_char]
+    execute 'norm! ' . get(b:AutoPairsNewlineIndentCommand, prev_char, '==')
     call append(line_n - 1, '')
-    execute 'norm! ' . get(b:AutoPairsNewlineIndentCommand, prev_char, '==k')
+    norm! k
     if &expandtab
       let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth)
     else

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -418,29 +418,18 @@ function! AutoPairsReturn()
   let prev_line = getline(line_n - 1)
   let prev_char = prev_line[len(prev_line) - 1]
   let remaining_line = getline(line_n)
+  let g:db = [prev_line, prev_char, remaining_line]
 
-  if has_key(b:AutoPairsNewline, prev_char) && remaining_line =~? '^' . b:AutoPairsNewline[prev_char]
-    if g:AutoPairsCenterLine && winline() * 3 >= winheight(0) * 2
-      " Recenter before adding new line to avoid replacing line content
-      let cmd = "zz"
-    end
-
-    " If equalprg has been set, then avoid call =
-    " https://github.com/jiangmiao/auto-pairs/issues/24
-    if &equalprg != ''
-      return "\<ESC>".cmd."O"
-    endif
-
-    " conflict with javascript and coffee
-    " javascript   need   indent new line
-    " coffeescript forbid indent new line
-    if &filetype == 'coffeescript' || &filetype == 'coffee'
-      return "\<ESC>".cmd."k==o"
+  if has_key(b:AutoPairsNewline, prev_char) && remaining_line =~? '^\s*' . b:AutoPairsNewline[prev_char]
+    call append(line_n - 1, '')
+    norm! gqqk
+    if &expandtab
+      let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth)
     else
-      return "\<ESC>".cmd."=ko"
+      let cmd = repeat("\<Tab>", max([0, matchend(prev_line, '^\t*')]) + 1)
     endif
   end
-  return ''
+  return cmd
 endfunction
 
 function! AutoPairsSpace()

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -16,6 +16,11 @@ if !exists('g:AutoPairs')
   let g:AutoPairs = {'(':')', '[':']', '{':'}',"'":"'",'"':'"', '`':'`'}
 end
 
+if !exists('g:AutoPairsNewline')
+  let g:AutoPairsNewline = deepcopy(g:AutoPairs)
+  let g:AutoPairsNewline['>'] = '<'
+end
+
 if !exists('g:AutoPairsParens')
   let g:AutoPairsParens = {'(':')', '[':']', '{':'}'}
 end
@@ -389,7 +394,10 @@ function! AutoPairsReturn()
   let prev_char = pline[strlen(pline)-1]
   let cmd = ''
   let cur_char = line[col('.')-1]
-  if has_key(b:AutoPairs, prev_char) && b:AutoPairs[prev_char] == cur_char
+  let next_char = line[col('.')]
+  if cur_char == '<' && next_char != '/' | return '' | endif
+
+  if has_key(b:AutoPairsNewline, prev_char) && b:AutoPairsNewline[prev_char] == cur_char
     if g:AutoPairsCenterLine && winline() * 3 >= winheight(0) * 2
       " Recenter before adding new line to avoid replacing line content
       let cmd = "zz"
@@ -443,6 +451,10 @@ function! AutoPairsInit()
 
   if !exists('b:AutoPairs')
     let b:AutoPairs = g:AutoPairs
+  end
+
+  if !exists('b:AutoPairsNewline')
+    let b:AutoPairsNewline = g:AutoPairsNewline
   end
 
   if !exists('b:AutoPairsMoveCharacter')

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -413,14 +413,13 @@ function! AutoPairsReturn()
   if b:autopairs_enabled == 0
     return ''
   end
-  let line = getline('.')
-  let pline = getline(line('.')-1)
-  let prev_char = pline[strlen(pline)-1]
   let cmd = ''
-  let cur_char = line[col('.')-1]
-  let next_char = line[col('.')]
+  let line_n = line('.')
+  let prev_line = getline(line_n - 1)
+  let prev_char = prev_line[len(prev_line) - 1]
+  let remaining_line = getline(line_n)
 
-  if has_key(b:AutoPairsNewline, prev_char) && b:AutoPairsNewline[prev_char] == cur_char
+  if has_key(b:AutoPairsNewline, prev_char) && remaining_line =~? '^' . b:AutoPairsNewline[prev_char]
     if g:AutoPairsCenterLine && winline() * 3 >= winheight(0) * 2
       " Recenter before adding new line to avoid replacing line content
       let cmd = "zz"

--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -422,9 +422,9 @@ function! AutoPairsReturn()
 
   if has_key(b:AutoPairsNewline, prev_char) && remaining_line =~? '^\s*' . b:AutoPairsNewline[prev_char]
     call append(line_n - 1, '')
-    norm! gqqk
+    norm! ==k
     if &expandtab
-      let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth)
+      let cmd = repeat(" ", max([0, matchend(prev_line, '^\s*')]) + &shiftwidth + 1)
     else
       let cmd = repeat("\<Tab>", max([0, matchend(prev_line, '^\t*')]) + 1)
     endif

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ -z "$EDITOR" ]; then
+  echo "set \$EDITOR or run the command with EDITOR=vim run_tests.sh"
+  exit 1
+fi
+
+if [ -z "$PLUGINS_PATH" ]; then
+  PLUGINS_PATH=/tmp/autopairs_test
+  if [ ! -d "$PLUGINS_PATH" ]; then
+    echo "\$PLUGINS_PATH not supplied, saving to /tmp/autopairs_test..."
+    mkdir $PLUGINS_PATH
+    git clone https://github.com/junegunn/vader.vim "$PLUGINS_PATH"/vader
+    git clone https://github.com/plasticboy/vim-markdown "$PLUGINS_PATH"/vim-markdown
+  fi
+fi
+
+echo "filetype off" > /tmp/autopairs_test_vimrc
+echo "set rtp+=." >> /tmp/autopairs_test_vimrc
+echo "set rtp+=$PLUGINS_PATH/vader" >> /tmp/autopairs_test_vimrc
+echo "set rtp+=$PLUGINS_PATH/vim-markdown" >> /tmp/autopairs_test_vimrc
+echo "set rtp+=$PLUGINS_PATH/vim-markdown/after" >> /tmp/autopairs_test_vimrc
+echo "filetype plugin indent on" >> /tmp/autopairs_test_vimrc
+echo "syntax enable" >> /tmp/autopairs_test_vimrc
+
+"$EDITOR" -Nu /tmp/autopairs_test_vimrc -c 'Vader test/*'

--- a/test/newline_after_html_tag.vader
+++ b/test/newline_after_html_tag.vader
@@ -1,27 +1,78 @@
 Before:
   set noautoindent
+  set shiftwidth=2
 After:
   let b:AutoPairsNewline = g:AutoPairsNewline
 
-Given (buffer with a tag inside):
-  <div></div>
+### TESTS WITH SPACES
+Given:
+  <article>
+    <div></div>
+  </article>
 
-Do:
+Do (insert with spaces - custom pair):
   :let b:AutoPairsNewline={ '>': '</' }\<CR>
-  5li\<CR>
+  :set expandtab\<CR>
+  j7li\<CR>
 
-Expect (newline is inserted):
-  <div>
+Then:
+  let lines = getline(1, line('$'))
+  AssertEqual lines, [
+    \ '<article>',
+    \ '  <div>',
+    \ '     ',
+    \ '  </div>',
+    \ '</article>'
+    \ ]
 
-  </div>
 
-Given (parenthesis newline - enabled by default):
+
+Given:
+  fn()
+
+Do (insert with spaces - enabled by default):
+  :set expandtab\<CR>
+  3li\<CR>
+
+Then:
+  let lines = getline(1, line('$'))
+  AssertEqual lines, [
+    \ 'fn(',
+    \ '   ',
+    \ '  )'
+    \ ]
+
+
+### TESTS WITH TABS
+Given (empty buffer):
+  
+Do (insert with tabs - custom pair):
+  :let b:AutoPairsNewline={ '>': '</' }\<CR>
+  :set noexpandtab\<CR>
+  i\<TAB><div></div>\<ESC>5hi\<CR>
+
+Then (should be tabs):
+  let lines = getline(1, line('$'))
+  "AssertEqual lines, [
+    "\ '	<div>',
+    "\ '		',
+    "\ '	</div>'
+    "\ ]
+  Assert match('^\t', lines[1]) > -1, "line is indented with tabs"
+
+
+Given (insert with tabs - enabled by default):
   fn()
 
 Do:
+  :set noexpandtab\<CR>
   3li\<CR>
 
-Expect (newline is inserted):
-  fn(
-
-    )
+Then (should be tabs):
+  let lines = getline(1, line('$'))
+  "AssertEqual lines, [
+  "\ 'fn(',
+  "\ '		',
+  "\ '	)'
+  "\ ]
+  Assert match('^\t', lines[1]) > -1, "line is indented with tabs"

--- a/test/newline_after_html_tag.vader
+++ b/test/newline_after_html_tag.vader
@@ -20,7 +20,7 @@ Then:
   AssertEqual lines, [
     \ '<article>',
     \ '  <div>',
-    \ '     ',
+    \ '    ',
     \ '  </div>',
     \ '</article>'
     \ ]
@@ -38,7 +38,7 @@ Then:
   let lines = getline(1, line('$'))
   AssertEqual lines, [
     \ 'fn(',
-    \ '   ',
+    \ '  ',
     \ '  )'
     \ ]
 

--- a/test/newline_after_html_tag.vader
+++ b/test/newline_after_html_tag.vader
@@ -1,0 +1,12 @@
+# test xml like tags
+Given (buffer with a tag inside):
+  <div></div>
+
+Do (insert newline between tags):
+  :let g:AutoPairsNewline={ '<': '>' }\<CR>
+  5li\<CR>
+
+Expect (newline is inserted):
+  <div>
+
+  </div>

--- a/test/newline_after_html_tag.vader
+++ b/test/newline_after_html_tag.vader
@@ -48,31 +48,25 @@ Given (empty buffer):
   
 Do (insert with tabs - custom pair):
   :let b:AutoPairsNewline={ '>': '</' }\<CR>
+  :set tabstop=2\<CR>
   :set noexpandtab\<CR>
   i\<TAB><div></div>\<ESC>5hi\<CR>
 
-Then (should be tabs):
-  let lines = getline(1, line('$'))
-  "AssertEqual lines, [
-    "\ '	<div>',
-    "\ '		',
-    "\ '	</div>'
-    "\ ]
-  Assert match('^\t', lines[1]) > -1, "line is indented with tabs"
+Expect:
+  	<div>
+  		
+  	</div>
 
 
 Given (insert with tabs - enabled by default):
   fn()
 
 Do:
+  :set tabstop=2\<CR>
   :set noexpandtab\<CR>
   3li\<CR>
 
-Then (should be tabs):
-  let lines = getline(1, line('$'))
-  "AssertEqual lines, [
-  "\ 'fn(',
-  "\ '		',
-  "\ '	)'
-  "\ ]
-  Assert match('^\t', lines[1]) > -1, "line is indented with tabs"
+Expect:
+  fn(
+  	
+  	)

--- a/test/newline_after_html_tag.vader
+++ b/test/newline_after_html_tag.vader
@@ -1,12 +1,27 @@
-# test xml like tags
+Before:
+  set noautoindent
+After:
+  let b:AutoPairsNewline = g:AutoPairsNewline
+
 Given (buffer with a tag inside):
   <div></div>
 
-Do (insert newline between tags):
-  :let g:AutoPairsNewline={ '<': '>' }\<CR>
+Do:
+  :let b:AutoPairsNewline={ '>': '</' }\<CR>
   5li\<CR>
 
 Expect (newline is inserted):
   <div>
 
   </div>
+
+Given (parenthesis newline - enabled by default):
+  fn()
+
+Do:
+  3li\<CR>
+
+Expect (newline is inserted):
+  fn(
+
+    )


### PR DESCRIPTION
**g:AutoPairsNewline** can be used for detecting a regular expression after the cursor position

`let g:AutoPairsNewline = extend(deepcopy(g:AutoPairs), {'>': '</'})` will insert newlines after tags.

**g:AutoPairsNewlineIndentCommand** can be used for executing a command to format the resulting lines, starting from the last line pushed down.

`let g:AutoPairsNewlineIndentCommand = { '>': 'gqqk' }`